### PR TITLE
fix: error handling in JSON unmarshalling for error responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -313,7 +313,7 @@ func sendRequest[T any](c *Client, req *http.Request) (T, error) {
 	// sometimes loops returns an "error": message, so check if that's the case and if so, return the error
 	errorMsg := &errorResponse{}
 	err = json.Unmarshal(body, &errorMsg)
-	if err == nil {
+	if err == nil && errorMsg.Error != "" {
 		return none, errors.New(errorMsg.Error)
 	}
 


### PR DESCRIPTION
At line 317 in client.go:313, the code was returning errors.New(errorMsg.Error) without checking if errorMsg.Error actually contains a value. Even when JSON unmarshaling succeeded, an empty Error field would result in an empty error message.

Fix applied: Added a check && errorMsg.Error != "" to ensure the Error field has a value before using it. This way, if the JSON parses successfully but the "error" field is empty, the code continues to the fallback error
   handling that uses the "message" field.
